### PR TITLE
Switch from multiprocessing to threading

### DIFF
--- a/midea_beautiful/command.py
+++ b/midea_beautiful/command.py
@@ -1,7 +1,7 @@
 """ Commands for Midea appliance """
 from __future__ import annotations
 
-from multiprocessing import RLock
+from threading import RLock
 from typing import ByteString
 
 from midea_beautiful.crypto import crc8

--- a/midea_beautiful/version.py
+++ b/midea_beautiful/version.py
@@ -1,2 +1,2 @@
 """ Version File """
-__version__ = "0.10.4"
+__version__ = "0.10.5"


### PR DESCRIPTION
Switch from multiprocessing to threading for the `Rlock` function. Multiprocessing requires `/dev/shm` which is now readonly in newer versions of docker-ce.