### PR TITLE
Add matrix testing for test framework

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -10,12 +10,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13', '3.12', '3.11', '3.10', '3.9', '3.8']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.x
         uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: '${{ matrix.python-version }}'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13', '3.12', '3.11', '3.10', '3.9', '3.8']
+        python-version: ['3.13', '3.12', '3.11', '3.10', '3.9']
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.x
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'


### PR DESCRIPTION
Add testing for all python versions the lib supports, perhaps it'll be worth dropping Python 3.8 at some point as it's EOL.