### PR TITLE
Added OS Comfort application choice

### DIFF
--- a/midea_beautiful/midea.py
+++ b/midea_beautiful/midea.py
@@ -69,6 +69,13 @@ SUPPORTED_APPS: Final = {
         ),
         "proxied": "v5",
     },
+    "OS Comfort": {
+        "appkey": "02021a881e4d4b21d7fed806719e5440",
+        "appid": 1114,
+        "apiurl": "https://mapp.appsmb.com",
+        "signkey": "xhdiwjnchekd4d512chdjx5d8e4c394D2D7S",
+        "proxied": None,
+    },
 }
 
 # spell-checker: ignore unsubscriptable


### PR DESCRIPTION
This PR adds support for Olimpia Splendid air conditioners managed through the OS Comfort app ([https://play.google.com/store/apps/details?id=com.olimpia.ac](https://play.google.com/store/apps/details?id=com.olimpia.ac)).
